### PR TITLE
3 bugfixes/enhancements following a feedback

### DIFF
--- a/Owin.Security.Providers/OpenID/OpenIDAuthenticationExtensions.cs
+++ b/Owin.Security.Providers/OpenID/OpenIDAuthenticationExtensions.cs
@@ -38,13 +38,35 @@ namespace Owin.Security.Providers.OpenID
         /// <returns>The updated <see cref="IAppBuilder"/></returns>
         public static IAppBuilder UseOpenIDAuthentication(this IAppBuilder app, string providerUri, string providerName)
         {
-            return UseOpenIDAuthentication(app, new OpenIDAuthenticationOptions
+            return UseOpenIDAuthentication(app, providerUri, providerName, false);
+        }
+
+        /// <summary>
+        /// Authenticate users using an OpenID provider
+        /// </summary>
+        /// <param name="app">The <see cref="IAppBuilder"/> passed to the configuration method</param>
+        /// <param name="providerUri">The uri of the OpenID provider</param>
+        /// <param name="providerName">Name of the OpenID provider</param>
+        /// <param name="uriIsProviderLoginUri">True if the specified uri is the provider login uri and not the provider discovery uri</param>
+        /// <returns>The updated <see cref="IAppBuilder"/></returns>
+        public static IAppBuilder UseOpenIDAuthentication(this IAppBuilder app, string providerUri, string providerName, bool uriIsProviderLoginUri)
+        {
+            var authOptions = new OpenIDAuthenticationOptions
             {
-                ProviderDiscoveryUri = providerUri,
                 Caption = providerName,
                 AuthenticationType = providerName,
                 CallbackPath = new PathString("/signin-openid" + providerName.ToLowerInvariant())
-            });
+            };
+            if (uriIsProviderLoginUri)
+            {
+                authOptions.ProviderLoginUri = providerUri;
+            }
+            else
+            {
+
+                authOptions.ProviderDiscoveryUri = providerUri;
+            }
+            return UseOpenIDAuthentication(app, authOptions);
         }
     }
 }

--- a/Owin.Security.Providers/OpenID/OpenIDAuthenticationHandler.cs
+++ b/Owin.Security.Providers/OpenID/OpenIDAuthenticationHandler.cs
@@ -305,7 +305,10 @@ namespace Owin.Security.Providers.OpenID
 
             if (challenge != null)
             {
-                await DoYadisDiscoveryAsync();
+                if (string.IsNullOrEmpty(Options.ProviderLoginUri))
+                {
+                    await DoYadisDiscoveryAsync();
+                }
 
                 if (!string.IsNullOrEmpty(Options.ProviderLoginUri))
                 {
@@ -405,7 +408,7 @@ namespace Owin.Security.Providers.OpenID
                     }
                 }
             }
-            
+
             // Get provider url from XRDS document
             XDocument xrdsDoc = XDocument.Parse(await httpResponse.Content.ReadAsStringAsync());
             Options.ProviderLoginUri = xrdsDoc.Root.Element(XName.Get("XRD", "xri://$xrd*($v*2.0)"))
@@ -470,7 +473,7 @@ namespace Owin.Security.Providers.OpenID
                 using (var responseStream = await response.Content.ReadAsStreamAsync())
                 {
                     XmlReader reader = XmlReader.Create(responseStream, new XmlReaderSettings { MaxCharactersFromEntities = 1024, XmlResolver = null, DtdProcessing = DtdProcessing.Prohibit });
-                  
+
                     while (await reader.ReadAsync() && reader.NodeType != XmlNodeType.Element)
                     { }
                     if (reader.NamespaceURI == XRD_NAMESPACE && reader.Name == "XRDS")

--- a/Owin.Security.Providers/OpenID/OpenIDAuthenticationMiddleware.cs
+++ b/Owin.Security.Providers/OpenID/OpenIDAuthenticationMiddleware.cs
@@ -49,7 +49,7 @@ namespace Owin.Security.Providers.OpenID
         public OpenIDAuthenticationMiddlewareBase(OwinMiddleware next, IAppBuilder app, T options)
             : base(next, options)
         {
-            if (String.IsNullOrWhiteSpace(Options.ProviderDiscoveryUri) && Options.AuthenticationType != Constants.DefaultAuthenticationType)
+            if (String.IsNullOrWhiteSpace(Options.ProviderDiscoveryUri) && String.IsNullOrWhiteSpace(Options.ProviderLoginUri) && Options.AuthenticationType != Constants.DefaultAuthenticationType)
             {
                 throw new ArgumentException(String.Format(CultureInfo.CurrentCulture, Resources.Exception_OptionMustBeProvided, "ProviderDiscoveryUri"));
             }

--- a/Owin.Security.Providers/OpenID/OpenIDAuthenticationOptions.cs
+++ b/Owin.Security.Providers/OpenID/OpenIDAuthenticationOptions.cs
@@ -75,7 +75,7 @@ namespace Owin.Security.Providers.OpenID
         /// <summary>
         /// The OpenID provider login uri
         /// </summary>
-        internal string ProviderLoginUri { get; set; }
+        public string ProviderLoginUri { get; set; }
 
         /// <summary>
         /// Initializes a new <see cref="OpenIDAuthenticationOptions"/>

--- a/OwinOAuthProvidersDemo/App_Start/Startup.Auth.cs
+++ b/OwinOAuthProvidersDemo/App_Start/Startup.Auth.cs
@@ -56,6 +56,10 @@ namespace OwinOAuthProvidersDemo
 
             //app.UseSteamAuthentication(applicationKey: "");
 
+            //app.UseOpenIDAuthentication("http://orange.fr", "Orange");
+            // Use OpenId provider login uri instead of discovery uri
+            //app.UseOpenIDAuthentication("http://openid.orange.fr/server", "Orange", true);
+
         }
     }
 }


### PR DESCRIPTION
Following the feedback of PinpointTownes in a [Katana Project thread](https://katanaproject.codeplex.com/discussions/448615#post1197969) :
- Fix a bug in Yadis Discovery when the XRDS doc is malformed
- Proper use of async / await
- Adds the possibility to skip the discovery phase by indicating directly the provider login uri instead of the provider discovery uri

All of the modifications can be tested via the sample application.
Let me know if you need anything else :)
