### PR TITLE
NullReferenceException in OpenID handler when no attribute exchange items are provided

### DIFF
--- a/Owin.Security.Providers/OpenID/OpenIDAuthenticationHandler.cs
+++ b/Owin.Security.Providers/OpenID/OpenIDAuthenticationHandler.cs
@@ -247,9 +247,13 @@ namespace Owin.Security.Providers.OpenID
                 {
                     nameValue = lastValue;
                 }
-                else
+                else if (!string.IsNullOrEmpty(emailValue) && emailValue.Contains("@"))
                 {
                     nameValue = emailValue.Substring(0, emailValue.IndexOf('@'));
+                }
+                else
+                {
+                    nameValue = claimedID;
                 }
             }
 


### PR DESCRIPTION
Some OpenID providers do not send any of the attribute exchange properties. In that case the OpenIDAuthenticationHandler throws a NullReferenceException in the SetIdentityInformations method because the emailValue variable is null.
