### PR TITLE
support for refresh token in Salesforce provider

### DIFF
--- a/Owin.Security.Providers/Salesforce/Provider/SalesforceAuthenticatedContext.cs
+++ b/Owin.Security.Providers/Salesforce/Provider/SalesforceAuthenticatedContext.cs
@@ -21,11 +21,13 @@ namespace Owin.Security.Providers.Salesforce
         /// <param name="context">The OWIN environment</param>
         /// <param name="user">The JSON-serialized user</param>
         /// <param name="accessToken">Salesforce Access token</param>
-        public SalesforceAuthenticatedContext(IOwinContext context, JObject user, string accessToken)
+        /// <param name="refreshToken">Salesforce Refresh token</param>
+        public SalesforceAuthenticatedContext(IOwinContext context, JObject user, string accessToken, string refreshToken)
             : base(context)
         {
             User = user;
             AccessToken = accessToken;
+            RefreshToken = refreshToken;
 
             Id = TryGetValue(user, "id");
             UserId = TryGetValue(user, "user_id");
@@ -53,6 +55,11 @@ namespace Owin.Security.Providers.Salesforce
         /// Gets the Salesforce access token
         /// </summary>
         public string AccessToken { get; private set; }
+
+        /// <summary>
+        /// Gets the Salesforce refresh token, if the application's scope allows it
+        /// </summary>
+        public string RefreshToken { get; private set; }
 
         /// <summary>
         /// Gets the Salesforce ID / User Info Endpoint

--- a/Owin.Security.Providers/Salesforce/SalesforceAuthenticationHandler.cs
+++ b/Owin.Security.Providers/Salesforce/SalesforceAuthenticationHandler.cs
@@ -83,6 +83,7 @@ namespace Owin.Security.Providers.Salesforce
                 // Deserializes the token response
                 dynamic response = JsonConvert.DeserializeObject<dynamic>(text);
                 string accessToken = (string)response.access_token;
+                string refreshToken = (string)response.refresh_token;
 
                 // Get the Salesforce user using the user info endpoint, which is part of the token - response.id
                 HttpRequestMessage userRequest = new HttpRequestMessage(HttpMethod.Get, (string)response.id + "?access_token=" + Uri.EscapeDataString(accessToken));
@@ -92,7 +93,7 @@ namespace Owin.Security.Providers.Salesforce
                 text = await userResponse.Content.ReadAsStringAsync();
                 JObject user = JObject.Parse(text);
 
-                var context = new SalesforceAuthenticatedContext(Context, user, accessToken);
+                var context = new SalesforceAuthenticatedContext(Context, user, accessToken, refreshToken);
                 context.Identity = new ClaimsIdentity(
                     Options.AuthenticationType,
                     ClaimsIdentity.DefaultNameClaimType,


### PR DESCRIPTION
It looks like the merge of branch 'payojbaral-master' re-added the Salesforce files to the project, so they are actually in there for v 1.6.  I have been using 1.6 and have been able to establish an Oauth connection to Salesforce with my external app.  One thing that would be useful to have access to is the refresh token that is returned in the call, which is the basis for this pull request.  This will allow you to obtain new access tokens once the original one expires.   Access token expiration is based on the session timeout setting defined in the Salesforce install.

Setting up a connected app in Salesforce is fairly straightforward - you can sign up for a developer org here https://developer.salesforce.com/en/signup, and then follow these instructions to set up a connected app: https://www.salesforce.com/us/developer/docs/api_rest/Content/intro_defining_remote_access_applications.htm.   If you want your app to be able to use a refresh token, it will only be returned if you specify the "Perform requests on your behalf at any time (refresh_token, offline_access)" scope in the connected app's definition in Salesforce.
