### PR TITLE
added ArcGIS Online provider

### DIFF
--- a/Owin.Security.Providers/ArcGISOnline/ArcGISOnlineAuthenticationExtensions.cs
+++ b/Owin.Security.Providers/ArcGISOnline/ArcGISOnlineAuthenticationExtensions.cs
@@ -1,0 +1,29 @@
+﻿using System;
+
+namespace Owin.Security.Providers.ArcGISOnline
+{
+    public static class ArcGISOnlineAuthenticationExtensions
+    {
+        public static IAppBuilder UseArcGISOnlineAuthentication(this IAppBuilder app,
+            ArcGISOnlineAuthenticationOptions options)
+        {
+            if (app == null)
+                throw new ArgumentNullException("app");
+            if (options == null)
+                throw new ArgumentNullException("options");
+
+            app.Use(typeof(ArcGISOnlineAuthenticationMiddleware), app, options);
+
+            return app;
+        }
+
+        public static IAppBuilder UseArcGISOnlineAuthentication(this IAppBuilder app, string clientId, string clientSecret)
+        {
+            return app.UseArcGISOnlineAuthentication(new ArcGISOnlineAuthenticationOptions
+            {
+                ClientId = clientId,
+                ClientSecret = clientSecret
+            });
+        }
+    }
+}

--- a/Owin.Security.Providers/ArcGISOnline/ArcGISOnlineAuthenticationHandler.cs
+++ b/Owin.Security.Providers/ArcGISOnline/ArcGISOnlineAuthenticationHandler.cs
@@ -1,0 +1,218 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.Owin;
+using Microsoft.Owin.Infrastructure;
+using Microsoft.Owin.Logging;
+using Microsoft.Owin.Security;
+using Microsoft.Owin.Security.Infrastructure;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Owin.Security.Providers.ArcGISOnline
+{
+    public class ArcGISOnlineAuthenticationHandler : AuthenticationHandler<ArcGISOnlineAuthenticationOptions>
+    {
+        private const string XmlSchemaString = "http://www.w3.org/2001/XMLSchema#string";
+
+        private readonly ILogger logger;
+        private readonly HttpClient httpClient;
+
+        public ArcGISOnlineAuthenticationHandler(HttpClient httpClient, ILogger logger)
+        {
+            this.httpClient = httpClient;
+            this.logger = logger;
+        }
+
+        protected override async Task<AuthenticationTicket> AuthenticateCoreAsync()
+        {
+            AuthenticationProperties properties = null;
+
+            try
+            {
+                string code = null;
+
+                IReadableStringCollection query = Request.Query;
+                IList<string> values = query.GetValues("code");
+                if (values != null && values.Count == 1)
+                {
+                    code = values[0];
+                }
+
+                string requestPrefix = Request.Scheme + "://" + Request.Host;
+                string redirectUri = requestPrefix + Request.PathBase + Options.CallbackPath;
+
+                // Build up the body for the token request
+                var body = new List<KeyValuePair<string, string>>();
+                body.Add(new KeyValuePair<string, string>("code", code));
+                body.Add(new KeyValuePair<string, string>("redirect_uri", redirectUri));
+                body.Add(new KeyValuePair<string, string>("client_id", Options.ClientId));
+                body.Add(new KeyValuePair<string, string>("client_secret", Options.ClientSecret));
+                body.Add(new KeyValuePair<string, string>("grant_type", "authorization_code"));
+
+                // Request the token
+                var requestMessage = new HttpRequestMessage(HttpMethod.Post, Options.Endpoints.TokenEndpoint);
+                requestMessage.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+                requestMessage.Content = new FormUrlEncodedContent(body);
+                HttpResponseMessage tokenResponse = await httpClient.SendAsync(requestMessage);
+                tokenResponse.EnsureSuccessStatusCode();
+                string text = await tokenResponse.Content.ReadAsStringAsync();
+
+                // Deserializes the token response
+                dynamic response = JsonConvert.DeserializeObject<dynamic>(text);
+                string accessToken = (string)response.access_token;
+
+                // Get the ArcGISOnline user
+                HttpRequestMessage userRequest = new HttpRequestMessage(HttpMethod.Get, Options.Endpoints.UserInfoEndpoint + "?f=json&token=" + Uri.EscapeDataString(accessToken));
+                userRequest.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+                HttpResponseMessage userResponse = await httpClient.SendAsync(userRequest, Request.CallCancelled);
+                userResponse.EnsureSuccessStatusCode();
+                text = await userResponse.Content.ReadAsStringAsync();
+                var user = JsonConvert.DeserializeObject<Owin.Security.Providers.ArcGISOnline.Provider.ArcGISOnlineUser>(text);
+
+                var context = new ArcGISOnlineAuthenticatedContext(Context, user, accessToken);
+                context.Identity = new ClaimsIdentity(
+                    Options.AuthenticationType,
+                    ClaimsIdentity.DefaultNameClaimType,
+                    ClaimsIdentity.DefaultRoleClaimType);
+                if (!string.IsNullOrEmpty(context.Id))
+                {
+                    context.Identity.AddClaim(new Claim(ClaimTypes.NameIdentifier, context.Id, XmlSchemaString, Options.AuthenticationType));
+                }
+                if (!string.IsNullOrEmpty(context.UserName))
+                {
+                    context.Identity.AddClaim(new Claim(ClaimsIdentity.DefaultNameClaimType, context.UserName, XmlSchemaString, Options.AuthenticationType));
+                }
+                if (!string.IsNullOrEmpty(context.Email))
+                {
+                    context.Identity.AddClaim(new Claim(ClaimTypes.Email, context.Email, XmlSchemaString, Options.AuthenticationType));
+                }
+                if (!string.IsNullOrEmpty(context.Name))
+                {
+                    context.Identity.AddClaim(new Claim("urn:ArcGISOnline:name", context.Name, XmlSchemaString, Options.AuthenticationType));
+                }
+                if (!string.IsNullOrEmpty(context.Link))
+                {
+                    context.Identity.AddClaim(new Claim("urn:ArcGISOnline:url", context.Link, XmlSchemaString, Options.AuthenticationType));
+                }
+                string baseUri =
+                    Request.Scheme +
+                    Uri.SchemeDelimiter +
+                    Request.Host +
+                    Request.PathBase;
+
+                context.Properties = new AuthenticationProperties
+                {
+                    RedirectUri = baseUri +
+                    "/Account/ExternalLoginCallback"
+                };
+
+                await Options.Provider.Authenticated(context);
+
+                return new AuthenticationTicket(context.Identity, context.Properties);
+            }
+            catch (Exception ex)
+            {
+                logger.WriteError(ex.Message);
+            }
+            return new AuthenticationTicket(null, properties);
+        }
+
+        protected override Task ApplyResponseChallengeAsync()
+        {
+            if (Response.StatusCode != 401)
+            {
+                return Task.FromResult<object>(null);
+            }
+
+            AuthenticationResponseChallenge challenge = Helper.LookupChallenge(Options.AuthenticationType, Options.AuthenticationMode);
+
+            if (challenge != null)
+            {
+                string baseUri =
+                    Request.Scheme +
+                    Uri.SchemeDelimiter +
+                    Request.Host +
+                    Request.PathBase;
+
+                string currentUri =
+                    baseUri +
+                    Request.Path +
+                    Request.QueryString;
+
+                string redirectUri =
+                    baseUri +
+                    Options.CallbackPath;
+
+                // comma separated
+                string scope = string.Join(",", Options.Scope);
+
+                string authorizationEndpoint =
+                    Options.Endpoints.AuthorizationEndpoint +
+                        "?client_id=" + Uri.EscapeDataString(Options.ClientId) +
+                        "&response_type=" + Uri.EscapeDataString(scope) +
+                        "&redirect_uri=" + Uri.EscapeDataString(redirectUri);
+
+                Response.Redirect(authorizationEndpoint);
+            }
+
+            return Task.FromResult<object>(null);
+        }
+
+        public override async Task<bool> InvokeAsync()
+        {
+            return await InvokeReplyPathAsync();
+        }
+
+        private async Task<bool> InvokeReplyPathAsync()
+        {
+            if (Options.CallbackPath.HasValue && Options.CallbackPath == Request.Path)
+            {
+                // TODO: error responses
+
+                AuthenticationTicket ticket = await AuthenticateAsync();
+                if (ticket == null)
+                {
+                    logger.WriteWarning("Invalid return state, unable to redirect.");
+                    Response.StatusCode = 500;
+                    return true;
+                }
+
+                var context = new ArcGISOnlineReturnEndpointContext(Context, ticket);
+                context.SignInAsAuthenticationType = Options.SignInAsAuthenticationType;
+                context.RedirectUri = ticket.Properties.RedirectUri;
+
+                await Options.Provider.ReturnEndpoint(context);
+
+                if (context.SignInAsAuthenticationType != null &&
+                    context.Identity != null)
+                {
+                    ClaimsIdentity grantIdentity = context.Identity;
+                    if (!string.Equals(grantIdentity.AuthenticationType, context.SignInAsAuthenticationType, StringComparison.Ordinal))
+                    {
+                        grantIdentity = new ClaimsIdentity(grantIdentity.Claims, context.SignInAsAuthenticationType, grantIdentity.NameClaimType, grantIdentity.RoleClaimType);
+                    }
+                    Context.Authentication.SignIn(context.Properties, grantIdentity);
+                }
+
+                if (!context.IsRequestCompleted && context.RedirectUri != null)
+                {
+                    string redirectUri = context.RedirectUri;
+                    if (context.Identity == null)
+                    {
+                        // add a redirect hint that sign-in failed in some way
+                        redirectUri = WebUtilities.AddQueryString(redirectUri, "error", "access_denied");
+                    }
+                    Response.Redirect(redirectUri);
+                    context.RequestCompleted();
+                }
+
+                return context.IsRequestCompleted;
+            }
+            return false;
+        }
+    }
+}

--- a/Owin.Security.Providers/ArcGISOnline/ArcGISOnlineAuthenticationMiddleware.cs
+++ b/Owin.Security.Providers/ArcGISOnline/ArcGISOnlineAuthenticationMiddleware.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Globalization;
+using System.Net.Http;
+using Microsoft.Owin;
+using Microsoft.Owin.Logging;
+using Microsoft.Owin.Security;
+using Microsoft.Owin.Security.DataHandler;
+using Microsoft.Owin.Security.DataProtection;
+using Microsoft.Owin.Security.Infrastructure;
+using Owin.Security.Providers.Properties;
+
+namespace Owin.Security.Providers.ArcGISOnline
+{
+    public class ArcGISOnlineAuthenticationMiddleware : AuthenticationMiddleware<ArcGISOnlineAuthenticationOptions>
+    {
+        private readonly HttpClient httpClient;
+        private readonly ILogger logger;
+
+        public ArcGISOnlineAuthenticationMiddleware(OwinMiddleware next, IAppBuilder app,
+            ArcGISOnlineAuthenticationOptions options)
+            : base(next, options)
+        {
+            if (String.IsNullOrWhiteSpace(Options.ClientId))
+                throw new ArgumentException(String.Format(CultureInfo.CurrentCulture,
+                    Resources.Exception_OptionMustBeProvided, "ClientId"));
+            if (String.IsNullOrWhiteSpace(Options.ClientSecret))
+                throw new ArgumentException(String.Format(CultureInfo.CurrentCulture,
+                    Resources.Exception_OptionMustBeProvided, "ClientSecret"));
+
+            logger = app.CreateLogger<ArcGISOnlineAuthenticationMiddleware>();
+
+            if (Options.Provider == null)
+                Options.Provider = new ArcGISOnlineAuthenticationProvider();
+
+            if (Options.StateDataFormat == null)
+            {
+                IDataProtector dataProtector = app.CreateDataProtector(
+                    typeof (ArcGISOnlineAuthenticationMiddleware).FullName,
+                    Options.AuthenticationType, "v2");
+                Options.StateDataFormat = new PropertiesDataFormat(dataProtector);
+            }
+
+            if (String.IsNullOrEmpty(Options.SignInAsAuthenticationType))
+                Options.SignInAsAuthenticationType = app.GetDefaultSignInAsAuthenticationType();
+
+            httpClient = new HttpClient(ResolveHttpMessageHandler(Options))
+            {
+                Timeout = Options.BackchannelTimeout,
+                MaxResponseContentBufferSize = 1024*1024*10,
+            };
+            httpClient.DefaultRequestHeaders.UserAgent.ParseAdd("Microsoft Owin ArcGISOnline middleware");
+            httpClient.DefaultRequestHeaders.ExpectContinue = false;
+        }
+
+        /// <summary>
+        ///     Provides the <see cref="T:Microsoft.Owin.Security.Infrastructure.AuthenticationHandler" /> object for processing
+        ///     authentication-related requests.
+        /// </summary>
+        /// <returns>
+        ///     An <see cref="T:Microsoft.Owin.Security.Infrastructure.AuthenticationHandler" /> configured with the
+        ///     <see cref="T:Owin.Security.Providers.ArcGISOnline.ArcGISOnlineAuthenticationOptions" /> supplied to the constructor.
+        /// </returns>
+        protected override AuthenticationHandler<ArcGISOnlineAuthenticationOptions> CreateHandler()
+        {
+            return new ArcGISOnlineAuthenticationHandler(httpClient, logger);
+        }
+
+        private HttpMessageHandler ResolveHttpMessageHandler(ArcGISOnlineAuthenticationOptions options)
+        {
+            HttpMessageHandler handler = options.BackchannelHttpHandler ?? new WebRequestHandler();
+
+            // If they provided a validator, apply it or fail.
+            if (options.BackchannelCertificateValidator != null)
+            {
+                // Set the cert validate callback
+                var webRequestHandler = handler as WebRequestHandler;
+                if (webRequestHandler == null)
+                {
+                    throw new InvalidOperationException(Resources.Exception_ValidatorHandlerMismatch);
+                }
+                webRequestHandler.ServerCertificateValidationCallback = options.BackchannelCertificateValidator.Validate;
+            }
+
+            return handler;
+        }
+    }
+}

--- a/Owin.Security.Providers/ArcGISOnline/ArcGISOnlineAuthenticationOptions.cs
+++ b/Owin.Security.Providers/ArcGISOnline/ArcGISOnlineAuthenticationOptions.cs
@@ -1,0 +1,145 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using Microsoft.Owin;
+using Microsoft.Owin.Security;
+
+namespace Owin.Security.Providers.ArcGISOnline
+{
+    public class ArcGISOnlineAuthenticationOptions : AuthenticationOptions
+    {
+        public class ArcGISOnlineAuthenticationEndpoints
+        {
+            /// <summary>
+            /// Endpoint which is used to redirect users to request ArcGISOnline access
+            /// </summary>
+            /// <remarks>
+            /// Defaults to https://www.arcgis.com/sharing/oauth2/authorize
+            /// </remarks>
+            public string AuthorizationEndpoint { get; set; }
+
+            /// <summary>
+            /// Endpoint which is used to exchange code for access token
+            /// </summary>
+            /// <remarks>
+            /// Defaults to https://www.arcgis.com/sharing/oauth2/token
+            /// </remarks>
+            public string TokenEndpoint { get; set; }
+
+            /// <summary>
+            /// Endpoint which is used to obtain user information after authentication
+            /// </summary>
+            /// <remarks>
+            /// Defaults to https://www.arcgis.com/sharing/rest/accounts/self
+            /// </remarks>
+            public string UserInfoEndpoint { get; set; }
+        }
+
+        private const string AuthorizationEndPoint = "https://www.arcgis.com/sharing/oauth2/authorize";
+        private const string TokenEndpoint = "https://www.arcgis.com/sharing/oauth2/token";
+        private const string UserInfoEndpoint = "https://www.arcgis.com/sharing/rest/accounts/self";
+
+        /// <summary>
+        ///     Gets or sets the a pinned certificate validator to use to validate the endpoints used
+        ///     in back channel communications belong to ArcGISOnline.
+        /// </summary>
+        /// <value>
+        ///     The pinned certificate validator.
+        /// </value>
+        /// <remarks>
+        ///     If this property is null then the default certificate checks are performed,
+        ///     validating the subject name and if the signing chain is a trusted party.
+        /// </remarks>
+        public ICertificateValidator BackchannelCertificateValidator { get; set; }
+
+        /// <summary>
+        ///     The HttpMessageHandler used to communicate with ArcGISOnline.
+        ///     This cannot be set at the same time as BackchannelCertificateValidator unless the value
+        ///     can be downcast to a WebRequestHandler.
+        /// </summary>
+        public HttpMessageHandler BackchannelHttpHandler { get; set; }
+
+        /// <summary>
+        ///     Gets or sets timeout value in milliseconds for back channel communications with ArcGISOnline.
+        /// </summary>
+        /// <value>
+        ///     The back channel timeout in milliseconds.
+        /// </value>
+        public TimeSpan BackchannelTimeout { get; set; }
+
+        /// <summary>
+        ///     The request path within the application's base path where the user-agent will be returned.
+        ///     The middleware will process this request when it arrives.
+        ///     Default value is "/signin-ArcGISOnline".
+        /// </summary>
+        public PathString CallbackPath { get; set; }
+
+        /// <summary>
+        ///     Get or sets the text that the user can display on a sign in user interface.
+        /// </summary>
+        public string Caption
+        {
+            get { return Description.Caption; }
+            set { Description.Caption = value; }
+        }
+
+        /// <summary>
+        ///     Gets or sets the ArcGISOnline supplied Client ID
+        /// </summary>
+        public string ClientId { get; set; }
+
+        /// <summary>
+        ///     Gets or sets the ArcGISOnline supplied Client Secret
+        /// </summary>
+        public string ClientSecret { get; set; }
+
+        /// <summary>
+        /// Gets the sets of OAuth endpoints used to authenticate against ArcGISOnline.  Overriding these endpoints allows you to use ArcGISOnline Enterprise for
+        /// authentication.
+        /// </summary>
+        public ArcGISOnlineAuthenticationEndpoints Endpoints { get; set; }
+
+        /// <summary>
+        ///     Gets or sets the <see cref="IArcGISOnlineAuthenticationProvider" /> used in the authentication events
+        /// </summary>
+        public IArcGISOnlineAuthenticationProvider Provider { get; set; }
+
+        /// <summary>
+        /// A list of permissions to request.
+        /// </summary>
+        public IList<string> Scope { get; private set; }
+
+        /// <summary>
+        ///     Gets or sets the name of another authentication middleware which will be responsible for actually issuing a user
+        ///     <see cref="System.Security.Claims.ClaimsIdentity" />.
+        /// </summary>
+        public string SignInAsAuthenticationType { get; set; }
+
+        /// <summary>
+        ///     Gets or sets the type used to secure data handled by the middleware.
+        /// </summary>
+        public ISecureDataFormat<AuthenticationProperties> StateDataFormat { get; set; }
+
+        /// <summary>
+        ///     Initializes a new <see cref="ArcGISOnlineAuthenticationOptions" />
+        /// </summary>
+        public ArcGISOnlineAuthenticationOptions()
+            : base("ArcGIS Online")
+        {
+            Caption = Constants.DefaultAuthenticationType;
+            CallbackPath = new PathString("/signin-arcgis-online");
+            AuthenticationMode = AuthenticationMode.Passive;
+            Scope = new List<string>
+            {
+                "code"
+            };
+            BackchannelTimeout = TimeSpan.FromSeconds(60);
+            Endpoints = new ArcGISOnlineAuthenticationEndpoints
+            {
+                AuthorizationEndpoint = AuthorizationEndPoint,
+                TokenEndpoint = TokenEndpoint,
+                UserInfoEndpoint = UserInfoEndpoint
+            };
+        }
+    }
+}

--- a/Owin.Security.Providers/ArcGISOnline/Constants.cs
+++ b/Owin.Security.Providers/ArcGISOnline/Constants.cs
@@ -1,0 +1,7 @@
+﻿namespace Owin.Security.Providers.ArcGISOnline
+{
+    internal static class Constants
+    {
+        public const string DefaultAuthenticationType = "ArcGIS Online";
+    }
+}

--- a/Owin.Security.Providers/ArcGISOnline/Provider/ArcGISOnlineAuthenticatedContext.cs
+++ b/Owin.Security.Providers/ArcGISOnline/Provider/ArcGISOnlineAuthenticatedContext.cs
@@ -1,0 +1,75 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using System;
+using System.Globalization;
+using System.Security.Claims;
+using System.Linq;
+using Microsoft.Owin;
+using Microsoft.Owin.Security;
+using Microsoft.Owin.Security.Provider;
+using Newtonsoft.Json.Linq;
+using Owin.Security.Providers.ArcGISOnline.Provider;
+
+namespace Owin.Security.Providers.ArcGISOnline
+{
+    /// <summary>
+    /// Contains information about the login session as well as the user <see cref="System.Security.Claims.ClaimsIdentity"/>.
+    /// </summary>
+    public class ArcGISOnlineAuthenticatedContext : BaseContext
+    {
+        /// <summary>
+        /// Initializes a <see cref="ArcGISOnlineAuthenticatedContext"/>
+        /// </summary>
+        /// <param name="context">The OWIN environment</param>
+        /// <param name="user">The ArcGIS Online user</param>
+        /// <param name="accessToken">ArcGISOnline Access token</param>
+        public ArcGISOnlineAuthenticatedContext(IOwinContext context, ArcGISOnlineUser user, string accessToken)
+            : base(context)
+        {
+            AccessToken = accessToken;
+
+            Id = user.user.username;
+            Name = user.user.fullName;
+            Link = "https://www.arcgis.com/sharing/rest/community/users/" + Id;
+            UserName = Id;
+            Email = user.user.email;
+        }
+
+        /// <summary>
+        /// Gets the ArcGISOnline access token
+        /// </summary>
+        public string AccessToken { get; private set; }
+
+        /// <summary>
+        /// Gets the ArcGISOnline user ID
+        /// </summary>
+        public string Id { get; private set; }
+
+        /// <summary>
+        /// Gets the user's name
+        /// </summary>
+        public string Name { get; private set; }
+
+        /// <summary>
+        /// Gets the user's email
+        /// </summary>
+        public string Email { get; private set; }
+
+        public string Link { get; private set; }
+
+        /// <summary>
+        /// Gets the ArcGISOnline username
+        /// </summary>
+        public string UserName { get; private set; }
+
+        /// <summary>
+        /// Gets the <see cref="ClaimsIdentity"/> representing the user
+        /// </summary>
+        public ClaimsIdentity Identity { get; set; }
+
+        /// <summary>
+        /// Gets or sets a property bag for common authentication properties
+        /// </summary>
+        public AuthenticationProperties Properties { get; set; }
+    }
+}

--- a/Owin.Security.Providers/ArcGISOnline/Provider/ArcGISOnlineAuthenticationProvider.cs
+++ b/Owin.Security.Providers/ArcGISOnline/Provider/ArcGISOnlineAuthenticationProvider.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Owin.Security.Providers.ArcGISOnline
+{
+    /// <summary>
+    /// Default <see cref="IArcGISOnlineAuthenticationProvider"/> implementation.
+    /// </summary>
+    public class ArcGISOnlineAuthenticationProvider : IArcGISOnlineAuthenticationProvider
+    {
+        /// <summary>
+        /// Initializes a <see cref="ArcGISOnlineAuthenticationProvider"/>
+        /// </summary>
+        public ArcGISOnlineAuthenticationProvider()
+        {
+            OnAuthenticated = context => Task.FromResult<object>(null);
+            OnReturnEndpoint = context => Task.FromResult<object>(null);
+        }
+
+        /// <summary>
+        /// Gets or sets the function that is invoked when the Authenticated method is invoked.
+        /// </summary>
+        public Func<ArcGISOnlineAuthenticatedContext, Task> OnAuthenticated { get; set; }
+
+        /// <summary>
+        /// Gets or sets the function that is invoked when the ReturnEndpoint method is invoked.
+        /// </summary>
+        public Func<ArcGISOnlineReturnEndpointContext, Task> OnReturnEndpoint { get; set; }
+
+        /// <summary>
+        /// Invoked whenever ArcGISOnline succesfully authenticates a user
+        /// </summary>
+        /// <param name="context">Contains information about the login session as well as the user <see cref="System.Security.Claims.ClaimsIdentity"/>.</param>
+        /// <returns>A <see cref="Task"/> representing the completed operation.</returns>
+        public virtual Task Authenticated(ArcGISOnlineAuthenticatedContext context)
+        {
+            return OnAuthenticated(context);
+        }
+
+        /// <summary>
+        /// Invoked prior to the <see cref="System.Security.Claims.ClaimsIdentity"/> being saved in a local cookie and the browser being redirected to the originally requested URL.
+        /// </summary>
+        /// <param name="context"></param>
+        /// <returns>A <see cref="Task"/> representing the completed operation.</returns>
+        public virtual Task ReturnEndpoint(ArcGISOnlineReturnEndpointContext context)
+        {
+            return OnReturnEndpoint(context);
+        }
+    }
+}

--- a/Owin.Security.Providers/ArcGISOnline/Provider/ArcGISOnlineReturnEndpointContext.cs
+++ b/Owin.Security.Providers/ArcGISOnline/Provider/ArcGISOnlineReturnEndpointContext.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using Microsoft.Owin;
+using Microsoft.Owin.Security;
+using Microsoft.Owin.Security.Provider;
+
+namespace Owin.Security.Providers.ArcGISOnline
+{
+    /// <summary>
+    /// Provides context information to middleware providers.
+    /// </summary>
+    public class ArcGISOnlineReturnEndpointContext : ReturnEndpointContext
+    {
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="context">OWIN environment</param>
+        /// <param name="ticket">The authentication ticket</param>
+        public ArcGISOnlineReturnEndpointContext(
+            IOwinContext context,
+            AuthenticationTicket ticket)
+            : base(context, ticket)
+        {
+        }
+    }
+}

--- a/Owin.Security.Providers/ArcGISOnline/Provider/ArcGISOnlineUser.cs
+++ b/Owin.Security.Providers/ArcGISOnline/Provider/ArcGISOnlineUser.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace Owin.Security.Providers.ArcGISOnline.Provider
+{
+    public class ArcGISOnlineUser
+    {
+        public User user { get; set; }
+    }
+
+    public class User
+    {
+        public string username { get; set; }
+        public string fullName { get; set; }
+        public string email { get; set; }
+    }
+}

--- a/Owin.Security.Providers/ArcGISOnline/Provider/IArcGISOnlineAuthenticationProvider.cs
+++ b/Owin.Security.Providers/ArcGISOnline/Provider/IArcGISOnlineAuthenticationProvider.cs
@@ -1,0 +1,24 @@
+﻿using System.Threading.Tasks;
+
+namespace Owin.Security.Providers.ArcGISOnline
+{
+    /// <summary>
+    /// Specifies callback methods which the <see cref="ArcGISOnlineAuthenticationMiddleware"></see> invokes to enable developer control over the authentication process. />
+    /// </summary>
+    public interface IArcGISOnlineAuthenticationProvider
+    {
+        /// <summary>
+        /// Invoked whenever ArcGISOnline succesfully authenticates a user
+        /// </summary>
+        /// <param name="context">Contains information about the login session as well as the user <see cref="System.Security.Claims.ClaimsIdentity"/>.</param>
+        /// <returns>A <see cref="Task"/> representing the completed operation.</returns>
+        Task Authenticated(ArcGISOnlineAuthenticatedContext context);
+
+        /// <summary>
+        /// Invoked prior to the <see cref="System.Security.Claims.ClaimsIdentity"/> being saved in a local cookie and the browser being redirected to the originally requested URL.
+        /// </summary>
+        /// <param name="context"></param>
+        /// <returns>A <see cref="Task"/> representing the completed operation.</returns>
+        Task ReturnEndpoint(ArcGISOnlineReturnEndpointContext context);
+    }
+}

--- a/Owin.Security.Providers/Owin.Security.Providers.csproj
+++ b/Owin.Security.Providers/Owin.Security.Providers.csproj
@@ -57,6 +57,16 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ArcGISOnline\ArcGISOnlineAuthenticationExtensions.cs" />
+    <Compile Include="ArcGISOnline\ArcGISOnlineAuthenticationHandler.cs" />
+    <Compile Include="ArcGISOnline\ArcGISOnlineAuthenticationMiddleware.cs" />
+    <Compile Include="ArcGISOnline\ArcGISOnlineAuthenticationOptions.cs" />
+    <Compile Include="ArcGISOnline\Constants.cs" />
+    <Compile Include="ArcGISOnline\Provider\ArcGISOnlineAuthenticatedContext.cs" />
+    <Compile Include="ArcGISOnline\Provider\ArcGISOnlineAuthenticationProvider.cs" />
+    <Compile Include="ArcGISOnline\Provider\ArcGISOnlineReturnEndpointContext.cs" />
+    <Compile Include="ArcGISOnline\Provider\ArcGISOnlineUser.cs" />
+    <Compile Include="ArcGISOnline\Provider\IArcGISOnlineAuthenticationProvider.cs" />
     <Compile Include="Buffer\BufferAuthenticationExtensions.cs" />
     <Compile Include="Buffer\BufferAuthenticationHandler.cs" />
     <Compile Include="Buffer\BufferAuthenticationMiddleware.cs" />

--- a/OwinOAuthProvidersDemo/App_Start/Startup.Auth.cs
+++ b/OwinOAuthProvidersDemo/App_Start/Startup.Auth.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNet.Identity;
 using Microsoft.Owin;
 using Microsoft.Owin.Security.Cookies;
 using Owin;
+using Owin.Security.Providers.ArcGISOnline;
 using Owin.Security.Providers.Buffer;
 using Owin.Security.Providers.GitHub;
 using Owin.Security.Providers.GooglePlus;
@@ -113,6 +114,10 @@ namespace OwinOAuthProvidersDemo
             //    ClientId = "",
             //    ClientSecret = ""
             //});
+
+            app.UseArcGISOnlineAuthentication(
+                clientId: "",
+                clientSecret: "");
         }
     }
 }


### PR DESCRIPTION
This adds a provider for authenticating with ArcGIS Online using a named user account using the [User logins via PHP, JSP, ASP.NET, and other server-based web apps](https://developers.arcgis.com/authentication/user-php-other.html) workflow. 

If you go to [developers.arcgis.com](https://developers.arcgis.com) and sign in you are able to create a new application to get the client Id and secret. You need a named user account to log in though, this is either an organizational account or a Portal for ArcGIS account.

Note that there is no state token passed so I had to set the `AuthenticationProperties` `RedirectUri` to the expected account controller callback method.
