### PR TITLE
Add GitHub Email information

### DIFF
--- a/Owin.Security.Providers/GitHub/GitHubAuthenticationHandler.cs
+++ b/Owin.Security.Providers/GitHub/GitHubAuthenticationHandler.cs
@@ -103,6 +103,10 @@ namespace Owin.Security.Providers.GitHub
                 {
                     context.Identity.AddClaim(new Claim(ClaimsIdentity.DefaultNameClaimType, context.UserName, XmlSchemaString, Options.AuthenticationType));
                 }
+                if (!string.IsNullOrEmpty(context.Email))
+                {
+                    context.Identity.AddClaim(new Claim(ClaimTypes.Email, context.Email, XmlSchemaString, Options.AuthenticationType));
+                }
                 if (!string.IsNullOrEmpty(context.Name))
                 {
                     context.Identity.AddClaim(new Claim("urn:github:name", context.Name, XmlSchemaString, Options.AuthenticationType));

--- a/Owin.Security.Providers/GitHub/Provider/GitHubAuthenticatedContext.cs
+++ b/Owin.Security.Providers/GitHub/Provider/GitHubAuthenticatedContext.cs
@@ -31,6 +31,7 @@ namespace Owin.Security.Providers.GitHub
             Name = TryGetValue(user, "name");
             Link = TryGetValue(user, "url");
             UserName = TryGetValue(user, "login");
+            Email = TryGetValue(user, "email");
         }
 
         /// <summary>
@@ -63,6 +64,11 @@ namespace Owin.Security.Providers.GitHub
         /// Gets the GitHub username
         /// </summary>
         public string UserName { get; private set; }
+
+        /// <summary>
+        /// Gets the GitHub email
+        /// </summary>
+        public string Email { get; private set; }
 
         /// <summary>
         /// Gets the <see cref="ClaimsIdentity"/> representing the user


### PR DESCRIPTION
Hello, the Email for the GitHub provider was missing in the context...
Just added that information (Email)
The GitHub includes Email is in the default "user" scope.

Kind regards, Nikolay.
