### PR TITLE
Allow LinkedIn scopes to be overriden per request

### DIFF
--- a/Owin.Security.Providers/LinkedIn/LinkedInAuthenticationHandler.cs
+++ b/Owin.Security.Providers/LinkedIn/LinkedInAuthenticationHandler.cs
@@ -171,6 +171,12 @@ namespace Owin.Security.Providers.LinkedIn
                 // comma separated
                 string scope = string.Join(",", Options.Scope);
 
+                // allow scopes to be specified via the authentication properties for this request, when specified they will already be comma separated
+                if (properties.Dictionary.ContainsKey("scope"))
+                {
+                    scope = properties.Dictionary["scope"];
+                }
+                
                 string state = Options.StateDataFormat.Protect(properties);
 
                 string authorizationEndpoint =


### PR DESCRIPTION
Allow customization of authentication scope via the properties
dictionary for the challenge.  Only when present will this override the
scope set during startup. This will allow for different scopes in
multi-function and tenant applications.
