### PR TITLE
Added ability to get Github emails in AuthenticationHandler

### DIFF
--- a/Owin.Security.Providers/GitHub/GitHubAuthenticationHandler.cs
+++ b/Owin.Security.Providers/GitHub/GitHubAuthenticationHandler.cs
@@ -119,9 +119,7 @@ namespace Owin.Security.Providers.GitHub
 
                 await Options.Provider.Authenticated(context);
 
-                var ticket = new AuthenticationTicket(context.Identity, context.Properties);
-
-                return ticket;
+                return new AuthenticationTicket(context.Identity, context.Properties);
             }
             catch (Exception ex)
             {

--- a/Owin.Security.Providers/GitHub/GitHubAuthenticationHandler.cs
+++ b/Owin.Security.Providers/GitHub/GitHubAuthenticationHandler.cs
@@ -111,11 +111,17 @@ namespace Owin.Security.Providers.GitHub
                 {
                     context.Identity.AddClaim(new Claim("urn:github:url", context.Link, XmlSchemaString, Options.AuthenticationType));
                 }
+                if (!string.IsNullOrEmpty(context.Email))
+                {
+                    context.Identity.AddClaim(new Claim(ClaimTypes.Email, context.Email, XmlSchemaString, Options.AuthenticationType));
+                }
                 context.Properties = properties;
 
                 await Options.Provider.Authenticated(context);
 
-                return new AuthenticationTicket(context.Identity, context.Properties);
+                var ticket = new AuthenticationTicket(context.Identity, context.Properties);
+
+                return ticket;
             }
             catch (Exception ex)
             {

--- a/Owin.Security.Providers/GitHub/Provider/GitHubAuthenticatedContext.cs
+++ b/Owin.Security.Providers/GitHub/Provider/GitHubAuthenticatedContext.cs
@@ -80,8 +80,6 @@ namespace Owin.Security.Providers.GitHub
         /// </summary>
         public AuthenticationProperties Properties { get; set; }
 
-
-
         private static string TryGetValue(JObject user, string propertyName)
         {
             JToken value;

--- a/Owin.Security.Providers/GitHub/Provider/GitHubAuthenticatedContext.cs
+++ b/Owin.Security.Providers/GitHub/Provider/GitHubAuthenticatedContext.cs
@@ -31,6 +31,7 @@ namespace Owin.Security.Providers.GitHub
             Name = TryGetValue(user, "name");
             Link = TryGetValue(user, "url");
             UserName = TryGetValue(user, "login");
+            Email = TryGetValue(user, "email");
         }
 
         /// <summary>
@@ -57,6 +58,11 @@ namespace Owin.Security.Providers.GitHub
         /// </summary>
         public string Name { get; private set; }
 
+        /// <summary>
+        /// Gets the user's email
+        /// </summary>
+        public string Email { get; private set; }
+
         public string Link { get; private set; }
 
         /// <summary>
@@ -73,6 +79,8 @@ namespace Owin.Security.Providers.GitHub
         /// Gets or sets a property bag for common authentication properties
         /// </summary>
         public AuthenticationProperties Properties { get; set; }
+
+
 
         private static string TryGetValue(JObject user, string propertyName)
         {


### PR DESCRIPTION
By default, Github is going to pass you the user email, but it wasn't being captured. This change ensures that, if present, the email will get captured when calling AuthenticationManager.GetExternalLoginInfo().
