### PR TITLE
Fix multiple scope request for Instagram

### DIFF
--- a/Owin.Security.Providers/Instagram/InstagramAuthenticationHandler.cs
+++ b/Owin.Security.Providers/Instagram/InstagramAuthenticationHandler.cs
@@ -156,8 +156,8 @@ namespace Owin.Security.Providers.Instagram
                 // OAuth2 10.12 CSRF
                 GenerateCorrelationId(properties);
 
-                // comma separated
-                string scope = string.Join(",", Options.Scope);
+                // plus separated (do not URL encode)
+                string scope = string.Join("+", Options.Scope);
 
                 string state = Options.StateDataFormat.Protect(properties);
 
@@ -166,7 +166,7 @@ namespace Owin.Security.Providers.Instagram
                         "?response_type=code" +
                         "&client_id=" + Uri.EscapeDataString(Options.ClientId) +
                         "&redirect_uri=" + Uri.EscapeDataString(redirectUri) +
-                        "&scope=" + Uri.EscapeDataString(scope) +
+                        "&scope=" + scope +
                         "&state=" + Uri.EscapeDataString(state);
 
                 Response.Redirect(authorizationEndpoint);


### PR DESCRIPTION
Fixed the issue where requesting multiple scopes from Instagram was giving the error "Invalid scope field(s): basic,likes". According to the docs, these must be separated by a '+':

http://instagram.com/developer/authentication/#scope
