### PR TITLE
Steam provider: expose more profile properties in identity claims

### DIFF
--- a/src/Owin.Security.Providers.Steam/SteamAuthenticationHandler.cs
+++ b/src/Owin.Security.Providers.Steam/SteamAuthenticationHandler.cs
@@ -14,11 +14,14 @@ namespace Owin.Security.Providers.Steam
 
         private const string UserInfoUri = "http://api.steampowered.com/ISteamUser/GetPlayerSummaries/v0002/?key={0}&steamids={1}";
 
+        private const string XmlSchemaString = "http://www.w3.org/2001/XMLSchema#string";
+
         public SteamAuthenticationHandler(HttpClient httpClient, ILogger logger) : base(httpClient, logger)
         { }
 
         protected override void SetIdentityInformations(ClaimsIdentity identity, string claimedID, IDictionary<string, string> attributeExchangeProperties)
         {
+            if (!Options.QueryProfile) return;
             var accountIDMatch = _accountIDRegex.Match(claimedID);
             if (!accountIDMatch.Success) return;
             var accountID = accountIDMatch.Groups[1].Value;
@@ -27,7 +30,12 @@ namespace Owin.Security.Providers.Steam
             getUserInfoTask.Wait();
             var userInfoRaw = getUserInfoTask.Result;
             dynamic userInfo = JsonConvert.DeserializeObject<dynamic>(userInfoRaw);
-            identity.AddClaim(new Claim(ClaimTypes.Name, (string)userInfo.response.players[0].personaname, "http://www.w3.org/2001/XMLSchema#string", Options.AuthenticationType));
+            identity.AddClaim(new Claim(ClaimTypes.Name, (string)userInfo.response.players[0].personaname, XmlSchemaString, Options.AuthenticationType));
+            identity.AddClaim(new Claim("urn:steam:id", userInfo.response.players[0].steamid, XmlSchemaString, Options.AuthenticationType));
+            identity.AddClaim(new Claim("urn:steam:profileurl", userInfo.response.players[0].profileurl, XmlSchemaString, Options.AuthenticationType));
+            identity.AddClaim(new Claim("urn:steam:avatar", userInfo.response.players[0].avatar, XmlSchemaString, Options.AuthenticationType));
+            identity.AddClaim(new Claim("urn:steam:avatarmedium", userInfo.response.players[0].avatarmedium, XmlSchemaString, Options.AuthenticationType));
+            identity.AddClaim(new Claim("urn:steam:avatarfull", userInfo.response.players[0].avatarfull, XmlSchemaString, Options.AuthenticationType));
         }
     }
 }

--- a/src/Owin.Security.Providers.Steam/SteamAuthenticationOptions.cs
+++ b/src/Owin.Security.Providers.Steam/SteamAuthenticationOptions.cs
@@ -7,6 +7,11 @@ namespace Owin.Security.Providers.Steam
     {
         public string ApplicationKey { get; set; }
 
+        /// <summary>
+        /// When enabled, the middleware will query Steam API for user profile and add some useful profile properties to claims.
+        /// </summary>
+        public bool QueryProfile { get; set; } = true;
+
         public SteamAuthenticationOptions()
         {
             ProviderDiscoveryUri = "http://steamcommunity.com/openid/";


### PR DESCRIPTION
And for users who want to query API by themselves (e.g. access properties that are not passed down by the middleware), they can disable Options.QueryProfile to avoid redundant HTTP requests.
