### PR TITLE
Update Twitch to latest API

### DIFF
--- a/src/Owin.Security.Providers.Twitch/Provider/TwitchAuthenticatedContext.cs
+++ b/src/Owin.Security.Providers.Twitch/Provider/TwitchAuthenticatedContext.cs
@@ -22,7 +22,7 @@ namespace Owin.Security.Providers.Twitch
         public TwitchAuthenticatedContext(IOwinContext context, JObject user, string accessToken)
             : base(context)
         {
-            User = user;
+            User = (JObject) ((JArray) users.GetValue("data")).First;
             AccessToken = accessToken;
 
             Id = TryGetValue(user, "_id");
@@ -36,7 +36,7 @@ namespace Owin.Security.Providers.Twitch
         /// Gets the JSON-serialized user
         /// </summary>
         /// <remarks>
-        /// Contains the Twitch user obtained from the User Info endpoint. By default this is https://api.Twitch.com/user but it can be
+        /// Contains the Twitch user obtained from the User Info endpoint. By default this is https://api.twitch.tv/helix/users but it can be
         /// overridden in the options
         /// </remarks>
         public JObject User { get; private set; }

--- a/src/Owin.Security.Providers.Twitch/Provider/TwitchAuthenticatedContext.cs
+++ b/src/Owin.Security.Providers.Twitch/Provider/TwitchAuthenticatedContext.cs
@@ -17,19 +17,19 @@ namespace Owin.Security.Providers.Twitch
         /// Initializes a <see cref="TwitchAuthenticatedContext"/>
         /// </summary>
         /// <param name="context">The OWIN environment</param>
-        /// <param name="user">The JSON-serialized user</param>
+        /// <param name="users">The JSON-serialized users</param>
         /// <param name="accessToken">Twitch Access token</param>
-        public TwitchAuthenticatedContext(IOwinContext context, JObject user, string accessToken)
+        public TwitchAuthenticatedContext(IOwinContext context, JObject users, string accessToken)
             : base(context)
         {
             User = (JObject) ((JArray) users.GetValue("data")).First;
             AccessToken = accessToken;
 
-            Id = TryGetValue(user, "_id");
-            Name = TryGetValue(user, "name");
-            Link = TryGetValue(user, "url");
-            UserName = TryGetValue(user, "name");
-            Email = TryGetValue(user, "email");
+            Id = TryGetValue(User, "_id");
+            Name = TryGetValue(User, "name");
+            Link = TryGetValue(User, "url");
+            UserName = TryGetValue(User, "name");
+            Email = TryGetValue(User, "email");
         }
 
         /// <summary>

--- a/src/Owin.Security.Providers.Twitch/TwitchAuthenticationHandler.cs
+++ b/src/Owin.Security.Providers.Twitch/TwitchAuthenticationHandler.cs
@@ -87,8 +87,9 @@ namespace Owin.Security.Providers.Twitch
                 var accessToken = (string)response.access_token;
 
                 // Get the Twitch user
-                var userRequest = new HttpRequestMessage(HttpMethod.Get, Options.Endpoints.UserInfoEndpoint + "?oauth_token=" + Uri.EscapeDataString(accessToken));
+                var userRequest = new HttpRequestMessage(HttpMethod.Get, Options.Endpoints.UserInfoEndpoint);
                 userRequest.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+                userRequest.Headers.Add("Authorization", "Bearer " + accessToken);
                 var userResponse = await _httpClient.SendAsync(userRequest, Request.CallCancelled);
                 userResponse.EnsureSuccessStatusCode();
                 text = await userResponse.Content.ReadAsStringAsync();

--- a/src/Owin.Security.Providers.Twitch/TwitchAuthenticationOptions.cs
+++ b/src/Owin.Security.Providers.Twitch/TwitchAuthenticationOptions.cs
@@ -14,7 +14,7 @@ namespace Owin.Security.Providers.Twitch
             /// Endpoint which is used to redirect users to request Twitch access
             /// </summary>
             /// <remarks>
-            /// Defaults to https://api.twitch.tv/kraken/oauth2/authorize
+            /// Defaults to https://id.twitch.tv/oauth2/authorize
             /// </remarks>
             public string AuthorizationEndpoint { get; set; }
 
@@ -22,7 +22,7 @@ namespace Owin.Security.Providers.Twitch
             /// Endpoint which is used to exchange code for access token
             /// </summary>
             /// <remarks>
-            /// Defaults to https://api.twitch.tv/kraken/oauth2/token
+            /// Defaults to https://id.twitch.tv/oauth2/token
             /// </remarks>
             public string TokenEndpoint { get; set; }
 
@@ -30,14 +30,14 @@ namespace Owin.Security.Providers.Twitch
             /// Endpoint which is used to obtain user information after authentication
             /// </summary>
             /// <remarks>
-            /// Defaults to https://api.twitch.tv/kraken/user
+            /// Defaults to https://api.twitch.tv/helix/users
             /// </remarks>
             public string UserInfoEndpoint { get; set; }
         }
 
-        private const string AuthorizationEndPoint = "https://api.twitch.tv/kraken/oauth2/authorize";
-        private const string TokenEndpoint = "https://api.twitch.tv/kraken/oauth2/token";
-        private const string UserInfoEndpoint = "https://api.twitch.tv/kraken/user";
+        private const string AuthorizationEndPoint = "https://id.twitch.tv/oauth2/authorize";
+        private const string TokenEndpoint = "https://id.twitch.tv/oauth2/token";
+        private const string UserInfoEndpoint = "https://api.twitch.tv/helix/users";
 
         /// <summary>
         ///     Gets or sets the a pinned certificate validator to use to validate the endpoints used
@@ -141,7 +141,7 @@ namespace Owin.Security.Providers.Twitch
             AuthenticationMode = AuthenticationMode.Passive;
             Scope = new List<string>
             {
-                "user_read"
+                "user:read:email"
             };
             BackchannelTimeout = TimeSpan.FromSeconds(60);
             Endpoints = new TwitchAuthenticationEndpoints


### PR DESCRIPTION
Should fix https://github.com/TerribleDev/OwinOAuthProviders/issues/241

Had to update the default claim as well since the old claim doesn't work in the new API.

Note that none of the existing Twitch APIs have a "Link" property but I still left them as is to avoid breaking changes.