### PR TITLE
Replaced comma with space on scope concatenation for linkedin

### DIFF
--- a/src/Owin.Security.Providers.LinkedIn/LinkedInAuthenticationHandler.cs
+++ b/src/Owin.Security.Providers.LinkedIn/LinkedInAuthenticationHandler.cs
@@ -121,7 +121,7 @@ namespace Owin.Security.Providers.LinkedIn
             GenerateCorrelationId(properties);
 
             // comma separated
-            var scope = string.Join(",", Options.Scope);
+            var scope = string.Join(" ", Options.Scope);
 
             // allow scopes to be specified via the authentication properties for this request, when specified they will already be comma separated
             if (properties.Dictionary.ContainsKey("scope"))


### PR DESCRIPTION
Modified as per documentation for 3 legged OAuth for linkedin
link: https://docs.microsoft.com/en-us/linkedin/shared/authentication/authorization-code-flow?context=linkedin/context

![image](https://user-images.githubusercontent.com/6542561/91272324-4b730e00-e79b-11ea-9da6-c3edb48de633.png)
